### PR TITLE
Fix breadcrumb display name typo

### DIFF
--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -102,7 +102,7 @@ const BreadcrumbEllipsis = ({
     <span className="sr-only">More</span>
   </span>
 )
-BreadcrumbEllipsis.displayName = "BreadcrumbElipssis"
+BreadcrumbEllipsis.displayName = "BreadcrumbEllipsis"
 
 export {
   Breadcrumb,


### PR DESCRIPTION
## Summary
- correct `BreadcrumbElipssis` typo

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683e6540d56c832989cb397503b9b46b