### PR TITLE
Fix Header dropdown menu markup

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -56,7 +56,7 @@ const Header = ({
                 {translations.products}
                 <ChevronDown className="h-4 w-4 bg-transparent backdrop-blur-sm" />
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="align="end" className="bg-white">
+              <DropdownMenuContent align="end" className="bg-white">
                 <DropdownMenuItem asChild>
                   <Link to="/session-management" className="block w-full bg-transparent backdrop-blur-sm">
                     {translations.sessionManagement}


### PR DESCRIPTION
## Summary
- fix duplicated `className` attribute in dropdown menu

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_683e65468594832984772acbaab43259