### PR TITLE
Add Vitest and cn tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-gfgfgfg
+# Shrinkwave
+
+This project uses Vite and React.
+
+## Running Tests
+
+Install dependencies and run:
+
+```bash
+npm test
+```
+
+Vitest will execute the test suite.
+

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -78,6 +79,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from './utils'
+
+describe('cn', () => {
+  it('joins class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar')
+  })
+
+  it('filters falsy values', () => {
+    expect(cn('foo', undefined, null, '', false, 'bar')).toBe('foo bar')
+  })
+
+  it('handles object syntax', () => {
+    expect(cn('foo', { bar: true, baz: false })).toBe('foo bar')
+  })
+
+  it('merges tailwind utilities', () => {
+    expect(cn('mx-2', 'mx-4')).toBe('mx-4')
+  })
+})


### PR DESCRIPTION
## Summary
- install `vitest` as a dev dependency
- add a `test` script
- create unit tests for the `cn` utility
- document how to run the tests in the README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e654dd798832980de7b756977b551