### PR TITLE
Fix duplicate class in Header dropdown

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -56,7 +56,7 @@ const Header = ({
                 {translations.products}
                 <ChevronDown className="h-4 w-4 bg-transparent backdrop-blur-sm" />
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="align="end" className="bg-white">
+              <DropdownMenuContent align="end" className="bg-white">
                 <DropdownMenuItem asChild>
                   <Link to="/session-management" className="block w-full bg-transparent backdrop-blur-sm">
                     {translations.sessionManagement}


### PR DESCRIPTION
## Summary
- fix duplicate `className` assignment in the `DropdownMenuContent` element in `Header.tsx`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e75d9ba80832987962c57c0c8de32